### PR TITLE
Release initrd-magisk v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Android x86 directory will be like this:
 
 - Execute `99_magisk` script to patch Android's root directory
   - Mount tmpfs on `/android/dev`.
-  - **On rootfs (read-write rootdir)**, directly add magisk binaries into `/android/magisk` and inject magisk services into `/init.rc`. **On system-as-root (read-only rootdir)**, mount overlay on `/android/system/etc/init`, add magisk binaries into `/android/system/etc/init/magisk` and inject magisk services into ` `/android/system/etc/init/magisk.rc`.
+  - **On rootfs (read-write rootdir)**, directly add magisk binaries into `/android/magisk` and inject magisk services into `/init.rc`. **On system-as-root (read-only rootdir)**, mount overlay on `/android/system/etc/init`, add magisk binaries into `/android/system/etc/init/magisk` and inject magisk services into  `/android/system/etc/init/magisk.rc`.
   - **Pre-init sepolicy patch**: Patch sepolicy file by using `magiskpolicy` tool, dump it into `/android/dev/.overlay/sepolicy` and mount bind on `/sepolicy` or vendor precompiled sepolicy.
   - Unmount `/android/dev`.
 - `init` switch root directory to `/android` and execute `/init` to boot Android.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Download initrd-magisk from [Release page](https://github.com/HuskyDG/initrd-mag
 1. In Android-x86 directory, rename `initrd.img` to `initrd_real.img` and put `initrd-magisk` as `initrd.img`.
 2. Download **magisk apk** and put it as `magisk.apk` in Android-x86 directory.
 
-## Second way
+### Second way
 
 1. Put `initrd-magisk.img` into Android-x86 directory. Search for line `initrd /$SOURCE_NAME/initrd.img` in GRUB custom code and change it to `initrd /$SOURCE_NAME/initrd-magisk.img`
 2. Download **magisk apk** and put it as `magisk.apk` in Android-x86 directory.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Download initrd-magisk from [Release page](https://github.com/HuskyDG/initrd-mag
 1. In Android-x86 directory, rename `initrd.img` to `initrd_real.img` and put `initrd-magisk` as `initrd.img`.
 2. Download **magisk apk** and put it as `magisk.apk` in Android-x86 directory.
 
-### Second way
+## Second way
 
 1. Put `initrd-magisk.img` into Android-x86 directory. Search for line `initrd /$SOURCE_NAME/initrd.img` in GRUB custom code and change it to `initrd /$SOURCE_NAME/initrd-magisk.img`
 2. Download **magisk apk** and put it as `magisk.apk` in Android-x86 directory.

--- a/README.md
+++ b/README.md
@@ -48,11 +48,10 @@ Android x86 directory will be like this:
 
 - Execute `99_magisk` script to patch Android's root directory
   - Mount tmpfs on `/android/dev`.
-  - On rootfs, directly add magisk binaries into `/android/magisk` and magisk services into `init.rc`
-  - On system-as-root, mount overlayfs on `/system/etc/init` and add magisk binaries and `magisk.rc`.
-  - Patch sepolicy file, dump it into `/android/dev/.overlay/sepolicy` and mount bind into `/sepolicy` or vendor precompiled sepolicy.
-  - Unmount `/android/dev`
-- `init` switch root to `/android` and execute `/init` to boot Android.
+  - **On rootfs (read-write rootdir)**, directly add magisk binaries into `/android/magisk` and inject magisk services into `/init.rc`. **On system-as-root (read-only rootdir)**, mount overlay on `/android/system/etc/init`, add magisk binaries into `/android/system/etc/init/magisk` and inject magisk services into ` `/android/system/etc/init/magisk.rc`.
+  - **Pre-init sepolicy patch**: Patch sepolicy file by using `magiskpolicy` tool, dump it into `/android/dev/.overlay/sepolicy` and mount bind on `/sepolicy` or vendor precompiled sepolicy.
+  - Unmount `/android/dev`.
+- `init` switch root directory to `/android` and execute `/init` to boot Android.
 
 ### Android boot stage
 
@@ -84,27 +83,7 @@ git clone http://github.com/huskydg/initrd-magisk
 cd ~/initrd-magisk
 ```
 
-4. Default is x86_64 (64bit)
-```
-cat <<EOF >bin/info.sh
-IS64BIT=true
-ABI=x86_64
-ABI32=x86
-EOF
-```
-
-  If you want to build initrd-magisk for Android x86 (32bit):
-
-```
-cat <<EOF >bin/info.sh
-IS64BIT=false
-ABI=x86
-ABI32=x86
-EOF
-```
-
-
-5. Build with these command:
+4. Build with these command:
 ```
 chmod -R 777 *; find * | cpio -o -H newc | gzip > ../initrd-magisk.img
 ```

--- a/bin/getprop
+++ b/bin/getprop
@@ -1,0 +1,3 @@
+#!/bin/busybox sh
+. "${0%/*}/utils.sh"
+"$(basename "$0")" $@

--- a/bin/info.sh
+++ b/bin/info.sh
@@ -1,3 +1,3 @@
-IS64BIT=false
-ABI=x86
+IS64BIT=true
+ABI=x86_64
 ABI32=x86

--- a/bin/info.sh
+++ b/bin/info.sh
@@ -1,3 +1,3 @@
-IS64BIT=true
-ABI=x86_64
+IS64BIT=false
+ABI=x86
 ABI32=x86

--- a/bin/info.sh
+++ b/bin/info.sh
@@ -1,3 +1,2 @@
-IS64BIT=true
-ABI=x86_64
-ABI32=x86
+MAGISKCORE=/magisk
+TMPDIR=/tmp

--- a/bin/magisk.sh
+++ b/bin/magisk.sh
@@ -36,7 +36,7 @@ cat /magisk/magisk.rc >>/android/init.rc
 else
 sysblock="$(mount | grep " /android " | tail -1 | awk '{ print $1 }')"
 mkdir /android/dev/system_root
-mount $sysblock /android/dev/system_root || mount -o ro $sysblock /dev/system_root
+mount $sysblock /android/dev/system_root || mount -o ro $sysblock /android/dev/system_root
 # prepare for second stage
 chmod 750 $inittmp
 umount -l /android/system/etc/init

--- a/bin/magisk.sh
+++ b/bin/magisk.sh
@@ -5,7 +5,7 @@ mount -t tmpfs tmpfs $inittmp
 mkdir -p $inittmp/.overlay/upper
 mkdir -p $inittmp/.overlay/work
 
-# . /bin/utils.sh
+. /bin/utils.sh
 
 if mount -t tmpfs | grep -q " /android " || mount -t rootfs | grep -q " /android "; then
 # rootfs, patch ramdisk

--- a/bin/magisk.sh
+++ b/bin/magisk.sh
@@ -23,7 +23,10 @@ mkdir /system_root
 mount $sysblock /system_root
 # prepare for second stage
 chmod 750 $inittmp
+umount -l /android/system/etc/init
 mount -t overlay tmpfs -o lowerdir=/android/system/etc/init,upperdir=$inittmp/.overlay/upper,workdir=$inittmp/.overlay/work /android/system/etc/init
+
+
 sed -i "s|MAGISK_FILES_BASE|/system/etc/init/magisk|g" /magisk/overlay.sh
 sed -i "s|MAGISK_FILES_BASE|/system/etc/init/magisk|g" /magisk/magisk.rc
 cp -a /magisk $inittmp/.overlay/upper
@@ -56,6 +59,7 @@ for module in $(ls /data/adb/modules); do
 
 bind_policy(){
 policy="$1"
+umount -l "$1"
 /magisk/magiskpolicy --load "$policy" --save "$inittmp/.overlay/policy" --magisk "allow * magisk_file lnk_file *"
 /magisk/magiskpolicy --load "$inittmp/.overlay/policy" --save "$inittmp/.overlay/policy" --apply "$module_policy"
 mount --bind $inittmp/.overlay/policy "$policy"

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -20,8 +20,6 @@ MP="$1"
 	elif [ -f /mnt/$SRC/data.img ]; then
 		remount_rw
 		mount -o loop,noatime /mnt/$SRC/data.img "$MP"
-	else
-		device_mount_data || mount -t tmpfs tmpfs "$MP"
 	fi
 }
 

--- a/init
+++ b/init
@@ -90,25 +90,14 @@ extract_magisk_apk(){
 
 
 
-[ "$IS64BIT" == "true" ] && mkdir -p "$TMPDIR/magisk32"
+mkdir -p "$TMPDIR/magisk32"
 mkdir -p "$TMPDIR/magisk"
  
 
-unzip -o "$APKFILE" "lib/$ABI/*" -d "$TMPDIR/magisk" &>/dev/null
+unzip -o "$APKFILE" "lib/x86_64/*" -d "$TMPDIR/magisk" &>/dev/null
 chmod -R 777 "$TMPDIR/magisk"
-
-if [ "$IS64BIT" == "true" ]; then
-unzip -o "$APKFILE" "lib/$ABI32/*" -d "$TMPDIR/magisk32" &>/dev/null
+unzip -o "$APKFILE" "lib/x86/*" -d "$TMPDIR/magisk32" &>/dev/null
 chmod -R 777 "$TMPDIR/magisk32"
-cp -af "$TMPDIR/magisk32/lib/$ABI32/"* "$MAGISKCORE"
-fi
-
-cp -af "$TMPDIR/magisk/lib/$ABI/"* "$MAGISKCORE"
-
-for file in magisk32 magisk64 magiskinit magiskpolicy busybox magiskboot; do
-rm -rf "$MAGISKCORE/$file"
-cp "$MAGISKCORE/lib${file}.so" "$MAGISKCORE/$file"
-done
 
 
 unzip -o "$APKFILE" 'assets/*' -x 'assets/chromeos/*' -d "$MAGISKCORE" &>/dev/null
@@ -571,8 +560,7 @@ if [ "$FIXFS" == "1" ]; then
 fi
 )
 
-MAGISKCORE=/magisk
-TMPDIR=/tmp
+
 MAGISKBASE=MAGISK_FILES_BASE
 . /bin/info.sh
 

--- a/init
+++ b/init
@@ -115,41 +115,23 @@ unzip -o "$APKFILE" 'assets/*' -x 'assets/chromeos/*' -d "$MAGISKCORE" &>/dev/nu
 
 }
 
-random(){
-VALUE=$1; TYPE=$2; PICK="$3"; PICKC="$4"
-TMPR=""
-HEX="0123456789abcdef"; HEXC=16
-CHAR="qwertyuiopasdfghjklzxcvbnm"; CHARC=26
-NUM="0123456789"; NUMC=10
-COUNT=$(seq 1 1 $VALUE)
-list_pick=$HEX; C=$HEXC
-[ "$TYPE" == "char" ] &&  list_pick=$CHAR && C=$CHARC 
-[ "$TYPE" == "number" ] && list_pick=$NUM && C=$NUMC 
-[ "$TYPE" == "custom" ] && list_pick="$PICK" && C=$PICKC 
-      for i in $COUNT; do
-          random_pick=$(( $RANDOM % $C))
-          echo -n ${list_pick:$random_pick:1}
-      done
-
-}
 
 random_str(){
-random_length=$(random 1 custom 56789 5);
-random $random_length custom "qwertyuiopasdfghjklzxcvbnm0123456789QWERTYUIOPASDFGHJKLZXCVBNM" 63 | base64 | sed "s/=//g"
+local FROM
+local TO
+FROM="$1"; TO="$2"
+tr -dc A-Za-z0-9 </dev/urandom | head -c $(($FROM+$(($RANDOM%$(($TO-$FROM+1))))))
 }
-
-
 
 
 magisk_loader(){
 
-magisk_overlay=`random_str`
-magisk_postfsdata=`random_str`
-magisk_service=`random_str`
-magisk_daemon=`random_str`
-magisk_boot_complete=`random_str`
-magisk_loadpolicy=`random_str`
-dev_random=`random_str`
+
+magisk_postfsdata=`random_str 6 15`
+magisk_service=`random_str 6 15`
+magisk_boot_complete=`random_str 6 15`
+
+dev_random=`random_str 7 10`
 
 
 # always use "/dev/<random_string>" as magisk tmpfs
@@ -331,9 +313,33 @@ mount --bind \"\$FROM\" \"\$TO\"
 fi
 ) }
 
+revert_changes(){
+#remount system read-only to fix Magisk fail to mount mirror
+
+if mount -t rootfs | grep -q \" / \" || mount -t tmpfs | grep -q \" / \"; then
+rm -rf /magisk
+fi
+
+
+mount -o ro,remount /
+mount -o ro,remount /system
+mount -o ro,remount /vendor
+mount -o ro,remount /product
+mount -o ro,remount /system_ext
+
+# unmount patched files
+
+umount -l /system/etc/init
+umount -l /init.rc
+umount -l /system/etc/init/hw/init.rc
+umount -l /sepolicy
+umount -l /system/vendor/etc/selinux/precompiled_sepolicy
+}
+
 
 exit_magisk(){
 umount -l $MAGISKTMP
+revert_changes
 echo -n >/dev/.magisk_unblock
 }
 
@@ -391,6 +397,7 @@ exec >>\$MAGISKTMP/emu/record_logs.txt
 
 cd $MAGISKBASE 
 
+test ! -f \"./\$magisk_name\" && magisk_name=magisk32
 test ! -f \"./\$magisk_name\" && { echo -n >/dev/.overlay_unblock; exit_magisk; exit 0; }
 
 
@@ -425,22 +432,7 @@ ln -s ./magiskpolicy \$MAGISKTMP/supolicy 2>/dev/null
 
 mkdir -p \$MAGISKTMP/.magisk/mirror
 mkdir \$MAGISKTMP/.magisk/block
-
 touch \$MAGISKTMP/.magisk/config
-
-
-#remount system read-only to fix Magisk fail to mount mirror
-
-if mount -t rootfs | grep -q \" / \" || mount -t tmpfs | grep -q \" / \"; then
-rm -rf /magisk
-fi
-
-
-mount -o ro,remount /
-mount -o ro,remount /system
-mount -o ro,remount /vendor
-mount -o ro,remount /product
-mount -o ro,remount /system_ext
 
 restorecon -R /data/adb/magisk
 
@@ -448,13 +440,8 @@ $ADDITIONAL_SCRIPT
 
 [ ! -f \"\$MAGISKTMP/magisk\" ] && exit_magisk
 
-# unmount patched files
+revert_changes
 
-umount -l /system/etc/init
-umount -l /init.rc
-umount -l /system/etc/init/hw/init.rc
-umount -l /sepolicy
-umount -l /system/vendor/etc/selinux/precompiled_sepolicy
 "
 }
 
@@ -537,7 +524,7 @@ echo -n >/dev/.initrd-magisk
 clear
 
 
-echo "initrd-magisk Android x86 v1.1"
+echo "initrd-magisk Android x86 v1.2"
 echo -n Initialize Magisk environment...
 
 [ -z "$SRC" -a -n "$BOOT_IMAGE" ] && SRC=`dirname $BOOT_IMAGE`
@@ -589,7 +576,7 @@ TMPDIR=/tmp
 MAGISKBASE=MAGISK_FILES_BASE
 . /bin/info.sh
 
-rm -rf /scripts/99_magisk
+rm -rf /scripts/*magisk*
 if [ -f "$APKFILE" ]; then
 cp /bin/magisk.sh /scripts/99_magisk
 mkdir -p "$MAGISKCORE"


### PR DESCRIPTION
- Get random strings from `/dev/urandom`
- Fail back to magic mount if overlayfs fails to mount
- Automatically detect `x86` or `x86_64` architecture